### PR TITLE
Depend on ansible-core for Python 3.8+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,10 @@ setup(
 
     packages=find_packages(exclude=['contrib', 'docs']),
 
-    install_requires=['ansible >= 2.5'],
+    install_requires=[
+        'ansible >= 2.5; python_version < "3.8"',
+        'ansible-core; python_version >= "3.8"',
+    ],
 
     extras_require={
         'argcomplete': ['argcomplete'],


### PR DESCRIPTION
Obsah only requires Ansible as an engine. The individual modules are not that important since no playbooks are shipped by default.