### PR TITLE
Support configuring multiple target names

### DIFF
--- a/obsah/__init__.py
+++ b/obsah/__init__.py
@@ -99,7 +99,9 @@ class Playbook(object):
         with open(self.path) as playbook_file:
             plays = yaml.safe_load(playbook_file.read())
 
-        return any(self.application_config.target_name() in play.get('hosts', []) for play in plays)
+        target_names = set(self.application_config.target_names())
+
+        return any(len(target_names.intersection(play.get('hosts', []))) > 0 for play in plays)
 
     @property
     def playbook_variables(self):
@@ -182,6 +184,13 @@ class ApplicationConfig(object):
         Return the name of the target in the playbook if the playbook takes a parameter.
         """
         return 'packages'
+
+    @staticmethod
+    def target_names():
+        """
+        Return an array of names of the target in the playbook if the playbook takes a parameter.
+        """
+        return [self.target_name()]
 
     @staticmethod
     def metadata_name():

--- a/tests/fixtures/inventory.yaml
+++ b/tests/fixtures/inventory.yaml
@@ -6,3 +6,7 @@ packages:
 server:
   hosts:
     testpackage: {}
+
+repos:
+  hosts:
+    myrepo: {}

--- a/tests/test_obsah.py
+++ b/tests/test_obsah.py
@@ -16,6 +16,14 @@ def application_config(playbooks_path):
         def playbooks_path():
             return playbooks_path.strpath
 
+        @staticmethod
+        def target_name():
+            return 'packages'
+
+        @staticmethod
+        def target_names():
+            return ['packages', 'repos']
+
     return MockApplicationConfig
 
 
@@ -34,6 +42,7 @@ def test_find_targets(fixture_dir):
     assert targets
     assert 'testpackage' in targets
     assert 'all' in targets
+    assert 'repos' in targets
 
 
 def test_playbook_constructor(application_config, playbooks_path):


### PR DESCRIPTION
The current design would require having to set `'packages` alongside another set of hosts. I have a example coming with Obal / foreman-packaging where I want to specify repository data within their own host group.