### PR TITLE
Add a dummy step for required checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,3 +38,14 @@ jobs:
         run: pip install -r requirements-test.txt
       - name: Run tests
         run: tox
+
+  tests:
+    if: always()
+    needs: build
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/tests/fixtures/help-3.12.txt
+++ b/tests/fixtures/help-3.12.txt
@@ -1,0 +1,12 @@
+usage: obsah [-h] action ...
+
+positional arguments:
+  action            which action to execute
+    dummy           Short description
+    multiple_plays
+    positional      positional argument test
+    repoclosure
+    setup
+
+options:
+  -h, --help        show this help message and exit

--- a/tests/test_obsah.py
+++ b/tests/test_obsah.py
@@ -127,7 +127,11 @@ def test_generate_ansible_args(playbooks_path, parser, cliargs, expected):
 
 
 def test_obsah_argument_parser_help(fixture_dir, parser):
-    path = fixture_dir / 'help.txt'
+    # https://github.com/python/cpython/commit/7cc773ba3d07d4a2e6cd39063fd1954abd6ae8f1
+    if sys.version_info >= (3, 12, 7):
+        path = fixture_dir / 'help-3.12.txt'
+    else:
+        path = fixture_dir / 'help.txt'
     expected = path.read()
     if sys.version_info >= (3, 10, 0):
         expected = expected.replace('optional arguments:', 'options:')


### PR DESCRIPTION
Depending on a matrix as required steps is painful to maintain. This adds a dummy step that can be used a required check. It depends on the matrix, so it only runs if CI completed.

This is split off from https://github.com/theforeman/obsah/pull/37 so I can adjust the required checks in advance.