### PR TITLE
Add Python 3.8 back

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
+          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39,py310,py311,py312,py313
+envlist = py38,py39,py310,py311,py312,py313
 
 [testenv]
 deps =
@@ -29,6 +29,7 @@ select = E,W,F
 
 [gh-actions]
 python =
+  3.8: py38
   3.9: py39
   3.10: py310
   3.11: py311


### PR DESCRIPTION
3cc621b2f93b949834f1407985a0f27b7b5dd310 declared Python >= 3.8 in setup.py but then removed 3.8 from the test matrix. This aligns everything again.

Fixes: 3cc621b2f93b ("Drop Python < 3.8 support")