### PR TITLE
Update documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: docs/conf.py
+
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: requirements-docs.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 exclude .bumpversion.cfg
+exclude .readthedocs.yaml
 include requirements*.txt
 include LICENSE
 include .coveragerc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Obsah'
-copyright = '2018, The Foreman'
+copyright = '2018 - 2024, The Foreman'
 author = 'The Foreman'
 
 try:

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -249,7 +249,7 @@ To decide on the next version, the git log is a good indicator. We can either do
 
     $ bumpversion patch
 
-This will modify all the files containing the version number, create a git commit and a GPG signed git tag. Once this is pushed, Travis will release it to PyPI:
+This will modify all the files containing the version number, create a git commit and a GPG signed git tag. Once this is pushed, GitHub Actions will release it to PyPI:
 
     $ git push
 


### PR DESCRIPTION
While reading the release docs I noticed it was wrong. Then, as always, I found more. The year of copyright was outdated. Also, the build was failing because a config file is now required.

This brings us closer to releasing a 1.0.0 version.