### PR TITLE
Correct required Python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 
 ## necessary tools
 
-- `python` (2 or 3)
+- `python` 3
 - `ansible`


### PR DESCRIPTION
Fixes: 3cc621b2f93b949834f1407985a0f27b7b5dd310 ("Drop Python < 3.8 support")