### PR TITLE
only mention python 3.8+ in develop docs

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -1,7 +1,7 @@
 Developing Obsah
 ===============
 
-Obsah is written with support for Python 2.7 and Python 3.5 or higher. To provide the command line we rely on the Python built in `argparse`_ and `Ansible`_. For testing we use `Pytest`_ but this is wrapped up with `Tox`_ to test multiple environments.
+Obsah is written with support for Python 3.8 or higher. To provide the command line we rely on the Python built in `argparse`_ and `Ansible`_. For testing we use `Pytest`_ but this is wrapped up with `Tox`_ to test multiple environments.
 
 .. _argparse: https://docs.python.org/3/library/argparse.html
 .. _Ansible: https://www.ansible.com/


### PR DESCRIPTION
Fixes: 3cc621b2f93b949834f1407985a0f27b7b5dd310 ("Drop Python < 3.8 support")
