### PR TITLE
Correct call to resources.path

### DIFF
--- a/obsah/__init__.py
+++ b/obsah/__init__.py
@@ -178,7 +178,6 @@ class ApplicationConfig(object):
         """
         return 'metadata.obsah.yaml'
 
-
     @staticmethod
     def data_path():
         """
@@ -186,8 +185,8 @@ class ApplicationConfig(object):
         """
         path = os.environ.get('OBSAH_DATA')
         if path is None:
-            # TODO: deprecated in 3.11
-            path = resources.path(__name__, 'data')
+            with resources.path(__name__, 'data') as fspath:
+                path = fspath.as_posix()
 
         return path
 


### PR DESCRIPTION
This method is a context manager and needs to be called as such.

It removes the TODO because while Python 3.11 marked it as deprecated, Python 3.12 undeprecated it again. While cleaning up it also removes a redundant empty line that violates pep8.

Fixes: c13603d63238 ("Replace pkg_resources with importlib")