### PR TITLE
don't fail when obsah_reset was never set

### DIFF
--- a/obsah/__init__.py
+++ b/obsah/__init__.py
@@ -414,10 +414,9 @@ def reset_args(application_config: ApplicationConfig, metadata: dict, args: argp
                     for arg in reset_values:
                         if arg in persist_params and persist_params[arg] == getattr(args, arg):
                             delattr(args, arg)
-            if args.obsah_reset:
-                for reset_arg in args.obsah_reset:
-                    with contextlib.suppress(AttributeError):
-                        delattr(args, reset_arg)
+            for reset_arg in getattr(args, 'obsah_reset', []):
+                with contextlib.suppress(AttributeError):
+                    delattr(args, reset_arg)
     return args
 
 


### PR DESCRIPTION
when a playbook has no parameters at all (like pull-images in foremanctl), `obsah_reset` is never added to the argparse Namespace and if there *are* persisted params (from a previous run of another playbook), you get an error:

    # foremanctl pull-images
    Traceback (most recent call last):
      File "/bin/obsah", line 33, in <module>
        sys.exit(load_entry_point('obsah==1.3.0', 'console_scripts', 'obsah')())
      File "/usr/lib/python3.9/site-packages/obsah/__init__.py", line 448, in main
        args = reset_args(application_config, args.playbook.metadata, args)
      File "/usr/lib/python3.9/site-packages/obsah/__init__.py", line 417, in reset_args
        if getattr(args, 'obsah_reset'):
    AttributeError: 'Namespace' object has no attribute 'obsah_reset'

Safeguard this case with a `getattr` with a `None` default