### PR TITLE
Use additive merge for included playbook constraints

### DIFF
--- a/obsah/__init__.py
+++ b/obsah/__init__.py
@@ -82,6 +82,18 @@ class RemoveAction(argparse.Action):
         setattr(namespace, self.dest, items)
 
 
+def _merge_constraints(base, other):
+    merged = dict(base)
+    for key, value in other.items():
+        if key in merged:
+            if not isinstance(merged[key], list) or not isinstance(value, list):
+                raise ValueError(f"Cannot merge constraint '{key}': both values must be lists")
+            merged[key] = merged[key] + value
+        else:
+            merged[key] = value
+    return merged
+
+
 @total_ordering
 class Playbook(object):
     """
@@ -122,7 +134,7 @@ class Playbook(object):
                 include_path = os.path.join(self.application_config.playbooks_path(), include, self.application_config.metadata_name())
                 include_data = self._load_metadata_file(include_path)
                 data['variables'] = data.get('variables', {}) | include_data.get('variables', {})
-                data['constraints'] = data.get('constraints', {}) | include_data.get('constraints', {})
+                data['constraints'] = _merge_constraints(data.get('constraints', {}), include_data.get('constraints', {}))
 
             self._metadata = {
                 'help': data.get('help'),

--- a/tests/test_obsah.py
+++ b/tests/test_obsah.py
@@ -121,6 +121,38 @@ def test_generate_ansible_args(playbooks_path, parser, cliargs, expected):
     assert ansible_args == base_expected + expected
 
 
+@pytest.mark.parametrize("base,other,expected", [
+    ({}, {}, {}),
+    ({'required_if': [['a', 1, ['b']]]}, {}, {'required_if': [['a', 1, ['b']]]}),
+    ({}, {'required_if': [['a', 1, ['b']]]}, {'required_if': [['a', 1, ['b']]]}),
+    (
+        {'required_if': [['a', 1, ['b']]]},
+        {'required_if': [['c', 2, ['d']]]},
+        {'required_if': [['a', 1, ['b']], ['c', 2, ['d']]]},
+    ),
+    (
+        {'required_if': [['a', 1, ['b']]], 'mutually_exclusive': [['x', 'y']]},
+        {'required_if': [['c', 2, ['d']]], 'required_together': [['m', 'n']]},
+        {
+            'required_if': [['a', 1, ['b']], ['c', 2, ['d']]],
+            'mutually_exclusive': [['x', 'y']],
+            'required_together': [['m', 'n']],
+        },
+    ),
+])
+def test_merge_constraints(base, other, expected):
+    assert obsah._merge_constraints(base, other) == expected
+
+
+@pytest.mark.parametrize("base,other", [
+    ({'key': 'string'}, {'key': ['list']}),
+    ({'key': ['list']}, {'key': 'string'}),
+])
+def test_merge_constraints_raises_on_non_list(base, other):
+    with pytest.raises(ValueError, match="both values must be lists"):
+        obsah._merge_constraints(base, other)
+
+
 def test_obsah_argument_parser_help(fixture_dir, parser):
     # https://github.com/python/cpython/commit/7cc773ba3d07d4a2e6cd39063fd1954abd6ae8f1
     if sys.version_info >= (3, 12, 7):


### PR DESCRIPTION
Constraints from included playbooks were merged with `|`, which overwrites existing constraint lists. Use a deep merge that concatenates lists under the same key so no rules are silently dropped.