### PR TITLE
Recursively resolve includes, merging variables and constraints

### DIFF
--- a/obsah/__init__.py
+++ b/obsah/__init__.py
@@ -119,6 +119,23 @@ class Playbook(object):
             data = {}
         return data
 
+    def _resolve_includes(self, data, visited=None):
+        """
+        Recursively resolve includes, merging variables and constraints.
+        """
+        if visited is None:
+            visited = set()
+
+        for include in data.get('include', []):
+            if include in visited:
+                continue
+            visited.add(include)
+            include_path = os.path.join(self.application_config.playbooks_path(), include, self.application_config.metadata_name())
+            include_data = self._load_metadata_file(include_path)
+            self._resolve_includes(include_data, visited)
+            data['variables'] = data.get('variables', {}) | include_data.get('variables', {})
+            data['constraints'] = data.get('constraints', {}) | include_data.get('constraints', {})
+
     @property
     def metadata(self) -> Mapping[str, Any]:
         """
@@ -131,11 +148,7 @@ class Playbook(object):
         """
         if not self._metadata:
             data = self._load_metadata_file(self._metadata_path)
-            for include in data.get('include', []):
-                include_path = os.path.join(self.application_config.playbooks_path(), include, self.application_config.metadata_name())
-                include_data = self._load_metadata_file(include_path)
-                data['variables'] = data.get('variables', {}) | include_data.get('variables', {})
-                data['constraints'] = _merge_constraints(data.get('constraints', {}), include_data.get('constraints', {}))
+            self._resolve_includes(data)
 
             self._metadata = {
                 'help': data.get('help'),

--- a/tests/fixtures/help-3.12.txt
+++ b/tests/fixtures/help-3.12.txt
@@ -1,13 +1,18 @@
 usage: obsah [-h] action ...
 
 positional arguments:
-  action            which action to execute
-    dummy           Short description
+  action                which action to execute
+    dummy               Short description
+    include_child
+    include_cycle_a
+    include_cycle_b
+    include_grandchild
+    include_parent      Parent playbook with includes
     multiple_plays
-    positional      positional argument test
+    positional          positional argument test
     repoclosure
     setup
-    types           Short description
+    types               Short description
 
 options:
-  -h, --help        show this help message and exit
+  -h, --help            show this help message and exit

--- a/tests/fixtures/help.txt
+++ b/tests/fixtures/help.txt
@@ -1,13 +1,18 @@
 usage: obsah [-h] action ...
 
 positional arguments:
-  action          which action to execute
-    dummy         Short description
+  action              which action to execute
+    dummy             Short description
+    include_child
+    include_cycle_a
+    include_cycle_b
+    include_grandchild
+    include_parent    Parent playbook with includes
     multiple_plays
-    positional    positional argument test
+    positional        positional argument test
     repoclosure
     setup
-    types         Short description
+    types             Short description
 
-optional arguments:
-  -h, --help      show this help message and exit
+options:
+  -h, --help          show this help message and exit

--- a/tests/fixtures/help.txt
+++ b/tests/fixtures/help.txt
@@ -14,5 +14,5 @@ positional arguments:
     setup
     types             Short description
 
-options:
+optional arguments:
   -h, --help          show this help message and exit

--- a/tests/fixtures/playbooks/include_child/include_child.yaml
+++ b/tests/fixtures/playbooks/include_child/include_child.yaml
@@ -1,0 +1,2 @@
+- hosts: packages
+  gather_facts: false

--- a/tests/fixtures/playbooks/include_child/metadata.obsah.yaml
+++ b/tests/fixtures/playbooks/include_child/metadata.obsah.yaml
@@ -1,0 +1,8 @@
+variables:
+  child_var:
+    help: Variable from child
+constraints:
+  required_if:
+    - ['child_var', 'x', ['automatic']]
+include:
+  - include_grandchild

--- a/tests/fixtures/playbooks/include_cycle_a/include_cycle_a.yaml
+++ b/tests/fixtures/playbooks/include_cycle_a/include_cycle_a.yaml
@@ -1,0 +1,2 @@
+- hosts: packages
+  gather_facts: false

--- a/tests/fixtures/playbooks/include_cycle_a/metadata.obsah.yaml
+++ b/tests/fixtures/playbooks/include_cycle_a/metadata.obsah.yaml
@@ -1,0 +1,5 @@
+variables:
+  cycle_a_var:
+    help: Variable from cycle_a
+include:
+  - include_cycle_b

--- a/tests/fixtures/playbooks/include_cycle_b/include_cycle_b.yaml
+++ b/tests/fixtures/playbooks/include_cycle_b/include_cycle_b.yaml
@@ -1,0 +1,2 @@
+- hosts: packages
+  gather_facts: false

--- a/tests/fixtures/playbooks/include_cycle_b/metadata.obsah.yaml
+++ b/tests/fixtures/playbooks/include_cycle_b/metadata.obsah.yaml
@@ -1,0 +1,5 @@
+variables:
+  cycle_b_var:
+    help: Variable from cycle_b
+include:
+  - include_cycle_a

--- a/tests/fixtures/playbooks/include_grandchild/include_grandchild.yaml
+++ b/tests/fixtures/playbooks/include_grandchild/include_grandchild.yaml
@@ -1,0 +1,2 @@
+- hosts: packages
+  gather_facts: false

--- a/tests/fixtures/playbooks/include_grandchild/metadata.obsah.yaml
+++ b/tests/fixtures/playbooks/include_grandchild/metadata.obsah.yaml
@@ -1,0 +1,6 @@
+variables:
+  grandchild_var:
+    help: Variable from grandchild
+constraints:
+  mutually_exclusive:
+    - ['grandchild_var', 'parent_var']

--- a/tests/fixtures/playbooks/include_parent/include_parent.yaml
+++ b/tests/fixtures/playbooks/include_parent/include_parent.yaml
@@ -1,0 +1,2 @@
+- hosts: packages
+  gather_facts: false

--- a/tests/fixtures/playbooks/include_parent/metadata.obsah.yaml
+++ b/tests/fixtures/playbooks/include_parent/metadata.obsah.yaml
@@ -1,0 +1,6 @@
+help: Parent playbook with includes
+variables:
+  parent_var:
+    help: Variable from parent
+include:
+  - include_child

--- a/tests/test_resolve_includes.py
+++ b/tests/test_resolve_includes.py
@@ -1,0 +1,42 @@
+import obsah
+import pytest
+
+
+@pytest.fixture
+def application_config(playbooks_path):
+    class MockApplicationConfig(obsah.ApplicationConfig):
+        @staticmethod
+        def playbooks_path():
+            return playbooks_path.strpath
+
+        @staticmethod
+        def target_name():
+            return 'packages'
+
+    return MockApplicationConfig
+
+
+def make_playbook(playbooks_path, application_config, name):
+    path = (playbooks_path / name / '{}.yaml'.format(name)).strpath
+    return obsah.Playbook(path, application_config)
+
+
+class TestResolveIncludes:
+    def test_single_include(self, playbooks_path, application_config):
+        playbook = make_playbook(playbooks_path, application_config, 'include_parent')
+        variables = {v.name for v in playbook.metadata['variables']}
+        assert 'parent_var' in variables
+        assert 'child_var' in variables
+        assert 'required_if' in playbook.metadata['constraints']
+
+    def test_recursive_include(self, playbooks_path, application_config):
+        playbook = make_playbook(playbooks_path, application_config, 'include_parent')
+        variables = {v.name for v in playbook.metadata['variables']}
+        assert 'grandchild_var' in variables
+        assert 'mutually_exclusive' in playbook.metadata['constraints']
+
+    def test_cyclic_includes(self, playbooks_path, application_config):
+        playbook = make_playbook(playbooks_path, application_config, 'include_cycle_a')
+        variables = {v.name for v in playbook.metadata['variables']}
+        assert 'cycle_a_var' in variables
+        assert 'cycle_b_var' in variables


### PR DESCRIPTION
The previous include resolution was single-level only. This extracts include handling into _resolve_includes() which walks the include tree recursively with cycle detection via a visited set, preventing infinite loops when playbooks include each other.

Tests cover single-level includes, multi-level (grandchild) includes, and cyclic include graphs.