### PR TITLE
Correctly merge constraints when resolving includes

### DIFF
--- a/obsah/__init__.py
+++ b/obsah/__init__.py
@@ -134,7 +134,7 @@ class Playbook(object):
             include_data = self._load_metadata_file(include_path)
             self._resolve_includes(include_data, visited)
             data['variables'] = data.get('variables', {}) | include_data.get('variables', {})
-            data['constraints'] = data.get('constraints', {}) | include_data.get('constraints', {})
+            data['constraints'] = _merge_constraints(data.get('constraints', {}), include_data.get('constraints', {}))
 
     @property
     def metadata(self) -> Mapping[str, Any]:

--- a/tests/fixtures/playbooks/include_parent/metadata.obsah.yaml
+++ b/tests/fixtures/playbooks/include_parent/metadata.obsah.yaml
@@ -2,5 +2,8 @@ help: Parent playbook with includes
 variables:
   parent_var:
     help: Variable from parent
+constraints:
+  required_if:
+    - ['parent_var', 'y', ['child_var']]
 include:
   - include_child

--- a/tests/test_resolve_includes.py
+++ b/tests/test_resolve_includes.py
@@ -35,6 +35,13 @@ class TestResolveIncludes:
         assert 'grandchild_var' in variables
         assert 'mutually_exclusive' in playbook.metadata['constraints']
 
+    def test_overlapping_constraints_are_merged(self, playbooks_path, application_config):
+        playbook = make_playbook(playbooks_path, application_config, 'include_parent')
+        required_if = playbook.metadata['constraints']['required_if']
+        assert ['parent_var', 'y', ['child_var']] in required_if
+        assert ['child_var', 'x', ['automatic']] in required_if
+        assert len(required_if) == 2
+
     def test_cyclic_includes(self, playbooks_path, application_config):
         playbook = make_playbook(playbooks_path, application_config, 'include_cycle_a')
         variables = {v.name for v in playbook.metadata['variables']}


### PR DESCRIPTION
0b96aa5082c3289a2615f171ba2d4dcc19333f57 accidentally dropped the call to _merge_constraints, regressing the additive merging of constraints we implemented earlier

Fixes: 0b96aa5082c3289a2615f171ba2d4dcc19333f57