### PR TITLE
Run pylint standalone instead of via pytest-pylint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,17 +9,18 @@ envlist = py39,py310,py311,py312,py313,py314
 [testenv]
 deps =
     check-manifest
-    pytest<9.1.0
+    pylint
+    pytest
     pytest-cov
     pytest-flakes
     pytest-forked
-    pytest-pylint
     pytest-xdist
     coveralls
 commands =
     check-manifest --ignore tox.ini,tests*,tests/**,docs*,docs/**,*/**/*.pyc,*/**/__pycache__
     python setup.py check -m -s
-    pytest -n 4 --flakes --pylint --pylint-rcfile={toxinidir}/.pylintrc --cov=obsah --cov-report term --cov-report xml --forked {posargs}
+    pylint --rcfile={toxinidir}/.pylintrc obsah
+    pytest -n 4 --flakes --cov=obsah --cov-report term --cov-report xml --forked {posargs}
     - coveralls
 
 [flake8]


### PR DESCRIPTION
## Summary

Companion of theforeman/obal#437. Same root cause applies here: `pytest-pylint` 0.21.0 hardcodes the pre-pytest-7 `pytest_collect_file(path, parent)` hookimpl signature with no version guard. pytest 9.0 removed the long-deprecated `path` parameter, so any environment resolving latest `pytest` fails at `pytest_configure` before a single test runs.

`obsah` previously worked around this by pinning `pytest<9.1.0` (#121), as discussed on obal#437. `pytest-pylint` looks effectively dead upstream (its pytest-9 compat fix was merged without ever cutting a release, and a follow-up compat PR has sat open unaddressed since 2025-12-16), so pinning `pytest` indefinitely isn't sustainable.

## Fix

Decouple pylint from pytest's plugin/collection API: run it as its own `tox` command instead of through `pytest --pylint`. This lets `pytest` go back to unpinned/latest and removes the `pytest<9.1.0` workaround. `.pylintrc` already scopes to the `obsah` package via `ignore=docs,tests`, so `pylint --rcfile=.pylintrc obsah` covers the same files `pytest-pylint` was checking.

## Verification

`tox -e py313` locally with latest resolved deps (`pytest==9.1.1`, `pylint` current): `120 passed`, pylint `10.00/10`. No other tox/CI/docs config references `pytest-pylint` or `--pylint`.